### PR TITLE
feat: add news_advanced page with date and news item table

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -2,6 +2,7 @@
 from django.http import HttpResponse, HttpRequest, JsonResponse
 from django.conf import settings
 from django.shortcuts import render
+from datetime import datetime
 
 
 def credits(request: HttpRequest) -> HttpResponse:
@@ -22,6 +23,22 @@ def news(request: HttpRequest) -> HttpResponse:
         ]
     }
     return render(request, "news.html", data)
+
+
+def news_advanced(request: HttpRequest) -> HttpResponse:
+    data = {
+        "news": [
+            (
+                datetime.strptime("2023-10-01", "%Y-%m-%d"),
+                "I have made it to section 3.6 of the book.",
+            ),
+            (
+                datetime.strptime("2023-10-02", "%Y-%m-%d"),
+                "RiffFriends has a news page.",
+            ),
+        ]
+    }
+    return render(request, "news_advanced.html", data)
 
 
 def version(request: HttpRequest) -> JsonResponse:

--- a/rifffriends/urls.py
+++ b/rifffriends/urls.py
@@ -25,4 +25,5 @@ urlpatterns = [
     path("about/", home_views.about, name="about"),
     path("version/", home_views.version, name="version"),
     path("news/", home_views.news, name="news"),
+    path("news_advanced/", home_views.news_advanced, name="news_advanced"),
 ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,6 +31,7 @@
                     <a href="{% url 'version' %}" class="nav-link">Version</a>
                     <a href="{% url 'about' %}" class="nav-link">About</a>
                     <a href="{% url 'credits' %}" class="nav-link">Credits</a>
+                    <a href="{% url 'news_advanced' %}" class="nav-link">News Advanced</a>
                 </div>
             </div>
         </div>

--- a/templates/news_advanced.html
+++ b/templates/news_advanced.html
@@ -1,0 +1,28 @@
+<!-- RiffFriends/templates/news_advanced.html -->
+{% extends "base.html" %}
+
+{% block title %}
+  {{block.super}}: News Advanced View
+{% endblock %}
+
+{% block content %}
+  <h1>RiffMates News</h1>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>News Item</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in news %}
+      <tr style="background-color: {% cycle 'lightblue' 'lightsteelblue' %};">
+          <td>{{ item.0|date:"D d M Y"  }}</td>
+          <td>{{ item.1 }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+{% endblock content %}


### PR DESCRIPTION
- Added news_advanced() view to home/views.py to display news items as tuples containing date and subject.
- Created news_advanced.html template to show the data in a table.
- Applied {% cycle %} tag for table row striping.
- Used |date filter to format the news item's date.